### PR TITLE
Add the dialog element as sectioning roots

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,7 @@ function hasHiddenAttribute(el) {
 exports.getTagName = getTagName;
 
 exports.hasHiddenAttribute = hasHiddenAttribute;
-exports.isSecRoot = tagChecker('^(BLOCKQUOTE|BODY|DETAILS|FIELDSET|FIGURE|TD)$');
+exports.isSecRoot = tagChecker('^(BLOCKQUOTE|BODY|DETAILS|DIALOG|FIELDSET|FIGURE|TD)$');
 exports.isSecContent = tagChecker('^(ARTICLE|ASIDE|NAV|SECTION)$');
 exports.isHeading = isHeading;
 exports.getRankingHeadingElement = getRankingHeadingElement;


### PR DESCRIPTION
According to the current [HTML Living Standard](https://html.spec.whatwg.org/multipage/sections.html#sectioning-root) (last updated 6 January 2018) and [HTML 5.2](https://www.w3.org/TR/html5/sections.html#sectioning-roots), the `dialog` element is a sectioning root. 

Supports it.